### PR TITLE
feat: add electron-based GUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,9 +9,10 @@ In the codex-rs folder where the rust code lives:
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
 
 Run `just fmt` (in `codex-rs` directory) automatically after making Rust code changes; do not ask for approval to run it. Before finalizing a change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
+
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
 2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
-When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+   When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
 
 ## TUI style conventions
 
@@ -27,6 +28,7 @@ See `codex-rs/tui/styles.md`.
     - Desired: vec!["  └ ".into(), "M".red(), " ".dim(), "tui/src/app.rs".dim()]
 
 ### TUI Styling (ratatui)
+
 - Prefer Stylize helpers: use "text".dim(), .bold(), .cyan(), .italic(), .underlined() instead of manual Style where possible.
 - Prefer simple conversions: use "text".into() for spans and vec![…].into() for lines; when inference is ambiguous (e.g., Paragraph::new/Cell::from), use Line::from(spans) or Span::from(text).
 - Computed styles: if the Style is computed at runtime, using `Span::styled` is OK (`Span::from(text).set_style(style)` is also acceptable).
@@ -38,6 +40,7 @@ See `codex-rs/tui/styles.md`.
 - Compactness: prefer the form that stays on one line after rustfmt; if only one of Line::from(vec![…]) or vec![…].into() avoids wrapping, choose that. If both wrap, pick the one with fewer wrapped lines.
 
 ### Text wrapping
+
 - Always use textwrap::wrap to wrap plain strings.
 - If you have a ratatui Line and you want to wrap it, use the helpers in tui/src/wrapping.rs, e.g. word_wrap_lines / word_wrap_line.
 - If you need to indent wrapped lines, use the initial_indent / subsequent_indent options from RtOptions if you can, rather than writing custom logic.
@@ -59,6 +62,7 @@ This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to va
   - `cargo insta accept -p codex-tui`
 
 If you don’t have the tool:
+
 - `cargo install cargo-insta`
 
 ### Test assertions

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ You can also use Codex with an API key, but this requires [additional setup](./d
 
 Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp). Enable by adding an `mcp_servers` section to your `~/.codex/config.toml`.
 
-
 ### Configuration
 
 Codex CLI supports a rich set of configuration options, with preferences stored in `~/.codex/config.toml`. For full configuration options, see [Configuration](./docs/config.md).
@@ -99,4 +98,3 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/codex-gui/index.html
+++ b/codex-gui/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>Codex GUI</title>
+<link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+<div id="settings">
+  Theme: <select id="theme"><option value="light">Light</option><option value="vs-dark">Dark</option></select>
+  Font Size: <input id="fontSize" type="number" min="10" max="24" />
+</div>
+<div id="container">
+  <div id="sidebar"></div>
+  <div id="main">
+    <div id="editor"></div>
+    <div id="panel">
+      <div id="terminal"></div>
+      <div id="output"></div>
+    </div>
+  </div>
+</div>
+<script type="module" src="renderer.js"></script>
+</body>
+</html>

--- a/codex-gui/main.js
+++ b/codex-gui/main.js
@@ -1,0 +1,59 @@
+const { app, BrowserWindow, ipcMain } = require("electron");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+const { readdir, readFile, writeFile } = require("node:fs/promises");
+const settings = require("./settings");
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+    },
+  });
+  win.loadFile(path.join(__dirname, "index.html"));
+  settings.onChange((s) => win.webContents.send("settings", s));
+}
+
+app.whenReady().then(() => {
+  createWindow();
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+
+ipcMain.handle("read-dir", async (_, dir) => {
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.map((e) => ({ name: e.name, isDir: e.isDirectory() }));
+});
+
+ipcMain.handle("read-file", (_, file) => readFile(file, "utf8"));
+
+ipcMain.handle("write-file", async (_, file, content) => {
+  await writeFile(file, content);
+  return true;
+});
+
+ipcMain.handle(
+  "run-command",
+  (event, command, cwd) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(command, { cwd, shell: true });
+      child.stdout.on("data", (d) =>
+        event.sender.send("command-data", d.toString()),
+      );
+      child.stderr.on("data", (d) =>
+        event.sender.send("command-data", d.toString()),
+      );
+      child.on("close", (code) => resolve(code));
+      child.on("error", reject);
+    }),
+);
+
+ipcMain.handle("get-settings", () => settings.get());
+ipcMain.handle("set-settings", (_, s) => settings.set(s));

--- a/codex-gui/package.json
+++ b/codex-gui/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "codex-gui",
+  "version": "0.1.0",
+  "private": true,
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "test": "echo \"No tests specified\""
+  },
+  "dependencies": {
+    "electron": "^31.0.0",
+    "monaco-editor": "^0.51.0",
+    "xterm": "^5.3.0",
+    "chokidar": "^3.6.0"
+  }
+}

--- a/codex-gui/preload.js
+++ b/codex-gui/preload.js
@@ -1,0 +1,15 @@
+const path = require("node:path");
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("api", {
+  readDir: (dir) => ipcRenderer.invoke("read-dir", dir),
+  readFile: (file) => ipcRenderer.invoke("read-file", file),
+  writeFile: (file, content) => ipcRenderer.invoke("write-file", file, content),
+  runCommand: (command, cwd) => ipcRenderer.invoke("run-command", command, cwd),
+  getSettings: () => ipcRenderer.invoke("get-settings"),
+  setSettings: (s) => ipcRenderer.invoke("set-settings", s),
+  pathJoin: (...args) => path.join(...args),
+  cwd: () => process.cwd(),
+  onSettings: (fn) => ipcRenderer.on("settings", (_, s) => fn(s)),
+  onCommandData: (fn) => ipcRenderer.on("command-data", (_, d) => fn(d)),
+});

--- a/codex-gui/renderer.js
+++ b/codex-gui/renderer.js
@@ -1,0 +1,103 @@
+import * as monaco from "monaco-editor";
+import { Terminal } from "xterm";
+
+const sidebar = document.getElementById("sidebar");
+const output = document.getElementById("output");
+const themeSelect = document.getElementById("theme");
+const fontInput = document.getElementById("fontSize");
+let editor;
+let terminal;
+
+async function init() {
+  const settings = await window.api.getSettings();
+  applySettings(settings);
+  themeSelect.value = settings.theme;
+  fontInput.value = settings.fontSize;
+  window.api.onSettings(applySettings);
+
+  editor = monaco.editor.create(document.getElementById("editor"), {
+    value: "",
+    language: "javascript",
+    theme: settings.theme,
+    fontSize: settings.fontSize,
+    automaticLayout: true,
+  });
+
+  terminal = new Terminal({ fontSize: settings.fontSize });
+  terminal.open(document.getElementById("terminal"));
+  terminal.write("> ");
+  let input = "";
+  terminal.onKey(async ({ key, domEvent }) => {
+    if (domEvent.key === "Enter") {
+      terminal.write("\r\n");
+      await window.api.runCommand(input, window.api.cwd());
+      input = "";
+      terminal.write("> ");
+    } else if (domEvent.key === "Backspace") {
+      if (input.length > 0) {
+        input = input.slice(0, -1);
+        terminal.write("\b \b");
+      }
+    } else {
+      input += key;
+      terminal.write(key);
+    }
+  });
+  window.api.onCommandData((d) => terminal.write(d));
+
+  loadDir(window.api.cwd());
+  themeSelect.addEventListener("change", updateSetting);
+  fontInput.addEventListener("change", updateSetting);
+}
+
+async function loadDir(dir) {
+  sidebar.innerHTML = "";
+  const entries = await window.api.readDir(dir);
+  entries.forEach((e) => {
+    const item = document.createElement("div");
+    item.textContent = e.name + (e.isDir ? "/" : "");
+    item.onclick = () => {
+      const full = window.api.pathJoin(dir, e.name);
+      if (e.isDir) loadDir(full);
+      else loadFile(full);
+    };
+    sidebar.appendChild(item);
+  });
+}
+
+async function loadFile(file) {
+  const content = await window.api.readFile(file);
+  editor.setValue(content);
+  editor._file = file;
+}
+
+async function saveFile() {
+  if (editor._file) {
+    await window.api.writeFile(editor._file, editor.getValue());
+    output.textContent = "Saved " + editor._file;
+  }
+}
+
+function applySettings(s) {
+  if (editor) {
+    monaco.editor.setTheme(s.theme);
+    editor.updateOptions({ fontSize: s.fontSize });
+  }
+  if (terminal) terminal.options.fontSize = s.fontSize;
+}
+
+function updateSetting() {
+  window.api.setSettings({
+    theme: themeSelect.value,
+    fontSize: Number(fontInput.value),
+  });
+}
+
+window.addEventListener("keydown", (e) => {
+  if (e.ctrlKey && e.key === "s") {
+    e.preventDefault();
+    saveFile();
+  }
+});
+
+init();

--- a/codex-gui/settings.js
+++ b/codex-gui/settings.js
@@ -1,0 +1,34 @@
+const { EventEmitter } = require("node:events");
+const { readFile, writeFile } = require("node:fs/promises");
+const { watch } = require("chokidar");
+const path = require("node:path");
+
+const configPath = path.join(__dirname, "settings.json");
+const events = new EventEmitter();
+let cache = {};
+
+async function load() {
+  try {
+    const data = await readFile(configPath, "utf8");
+    cache = JSON.parse(data);
+  } catch {
+    cache = { theme: "light", fontSize: 14 };
+    await writeFile(configPath, JSON.stringify(cache, null, 2));
+  }
+  events.emit("change", cache);
+}
+
+async function save(newSettings) {
+  cache = { ...cache, ...newSettings };
+  await writeFile(configPath, JSON.stringify(cache, null, 2));
+  events.emit("change", cache);
+}
+
+watch(configPath).on("change", load);
+load();
+
+module.exports = {
+  onChange: (fn) => events.on("change", fn),
+  get: () => cache,
+  set: save,
+};

--- a/codex-gui/styles.css
+++ b/codex-gui/styles.css
@@ -1,0 +1,8 @@
+body,html{height:100%;margin:0;font-family:sans-serif}
+#settings{height:40px;padding:5px;background:#ddd}
+#container{display:flex;height:calc(100% - 40px)}
+#sidebar{width:200px;background:#f3f3f3;overflow:auto}
+#main{flex:1;display:flex;flex-direction:column}
+#editor{flex:1}
+#panel{height:200px;display:flex;border-top:1px solid #ccc}
+#terminal,#output{flex:1;overflow:auto}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - docs
+  - codex-gui
 
 ignoredBuiltDependencies:
   - esbuild


### PR DESCRIPTION
## Summary
- stream Codex CLI commands in GUI terminal for full option support
- expose IPC channel for real-time command output
- hook renderer terminal to IPC and prompt-based input

## Testing
- `npm test` (missing script)
- `npm test` in `codex-gui`
- `pnpm format`


------
https://chatgpt.com/codex/tasks/task_e_68befd4db44c832898c5ae3e524f11da